### PR TITLE
Improve typography across site

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Montserrat);
-@import url(http://fonts.googleapis.com/css?family=Playfair+Display);
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap');
 
 
 * {
@@ -11,7 +10,9 @@
   overflow: hidden;
   background-color: transparent;
   font-family: 'Montserrat' !important;
-  font-size: 1.2rem;
+  font-size: 0.875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .custom-navbar a {
@@ -79,9 +80,14 @@
   font-size: 2.0em;
 }
 
+.text p {
+  margin-bottom: 1.4em;
+}
+
 .text {
-  font-size: 1.2em;
-  font-weight: lighter;
+  font-size: 1.05rem;
+  font-weight: 400;
+  line-height: 1.8;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -34,15 +34,16 @@
       <img class="portrait" src="img/Headshot_2024_09.jpg" alt="Zachary Senick">
     </div>
     <div class="text">
+      <p><span class="about-title">Zachary Senick (Захар Сенюк)</span></p>
       <p>
-        <span class="about-title">Zachary Senick (Захар Сенюк) </span> <br><br>
         Originally from Saskatoon, Saskatchewan, he began his bassoon studies at age 16 with Marie Sellar. He holds a
         BMus in Orchestral Performance at McGill University under Stéphane Lévesque and a MMus in Instrumental
         Performance at the University of Toronto under Eric Hall, and a doctorate of musical arts from the University of
         Toronto where he defended his thesis "Slava Ukraini: An Annotated Catalog of Ukrainian Solo and Chamber Bassoon
         Works." It was supervised by Robin Elliot with involvement from other committee members Gary Kulesha and Eric
         Hall.
-        <br><br>
+      </p>
+      <p>
         He has been a member of the National Youth Orchestra of Canada, Orchestre de la Francophonie and a substitute
         with the Canadian Opera Company, Windsor Symphony Orchestra, Peterborough Symphony Orchestra, Guelph Symphony,
         and Ontario Philharmonic. An avid contemporary performer he has works written for and dedicated to him by
@@ -59,29 +60,34 @@
         chamber ensemble), Dmytro Malyi (4 Archaic Songs for wind quartet), George Reshetar (Forgetten Legends for wind
         quartet), George Savransky (Travel to Yourself for bassoon and string quartet), Bohdan Syroyid (Kozak Suite for
         solo bassoon), Nadya Poklad (The Moon and the Stars for bassoon and piano).
-        <br><br>
+      </p>
+      <p>
         He has also given the world premiere of works by Ukrainian composers <a
           href="https://sites.google.com/view/alexanderjacobchuk">Alexander Jacobchuk</a> (Sonata-ballade for bassoon
         and piano), Yuri Polovotsky (Concerto op. 29). Oleksii Shvyrkunov (Four Miniature Scenes for oboe and
-        bassoon),and Volodymyr Pavensky (Wind Quintet op. 23), Nathan Lomov (Melodie for solo bassoon) along with the
+        bassoon), and Volodymyr Pavensky (Wind Quintet op. 23), Nathan Lomov (Melodie for solo bassoon) along with the
         North American premiere of around 20 works. In 2022, he was awarded the Hnatyshyn Foundation's Ukraine
         Heritage-Spirit and Future grant and performed for the Governor General of Canada at Rideau Hall in June 2023.
         He has performed internationally giving a solo recital in June 2025 at the International Double Reed Society
         conference at Butler University, USA.
-        <br><br>
+      </p>
+      <p>
         Senick is the founder and director of the Slava Ukraini Winds (<a
           href="https://www.slavaukrainiwinds.com">www.slavaukrainiwinds.com</a>) that perform, premiere, and record
         works by Ukrainian composers. They have provided the first existing recordings of many works and are performing a
         recital in July 2026 at the International Double Reed Society in Ohio, USA.
-        <br><br>
+      </p>
+      <p>
         In addition to performing, he is currently a music editor for Éditions Plamondon producing publications for
         their <a href="https://editionsplamondon.com/collections/slava-ukraini-series">Slava Ukraini Series</a>.
-        <br><br>
+      </p>
+      <p>
         He has been working as an archivist and music librarian as he is currently the orchestral librarian for the
         Windsor Symphony Orchestra. In the past he was a summer library assistant for the Canadian Music Centre at their
         national office in Toronto and curator for the George Zukerman Collection through the Council of Canadian
         Bassoonists, and a music librarian at the International Music Camp.
-        <br><br>
+      </p>
+      <p>
         In the past he has been a music instructor at the Vernon Cadet Training Centre's summer program for 2018-2019,
         and maintains an active woodwind private studio. In his free time, Senick is an avid cook, and his favorite
         things to make are вареники (varenyky/perogies) and борщ (borsch).


### PR DESCRIPTION
## Summary
- Fixes Google Fonts imports (HTTP → HTTPS, `display=swap`) — was blocking render on every page load
- `.text`: `font-weight: lighter` → `400`, `1.2em` → `1.05rem`, adds `line-height: 1.8` (none was set)
- Navbar: `1.2rem` → `0.875rem` with `letter-spacing: 0.08em` and `text-transform: uppercase`
- Bio `index.html`: replaces `<br><br>` spacing with proper `<p>` tags and `margin-bottom: 1.4em` for consistent vertical rhythm

## Test plan
- [ ] Verify fonts load without render-blocking flash on first visit
- [ ] Check bio paragraph spacing on desktop and mobile
- [ ] Confirm navbar labels are legible at reduced size with uppercase/tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)