### PR TITLE
Fix about-grid layout: row height, max-width, portrait margins

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -46,13 +46,10 @@
 .portrait {
   border-radius: 10px;
   border: 2px solid rgb(0, 0, 0);
-  margin: 20px auto;
-  /* Add space between images */
   max-width: 70%;
   height: auto;
-  margin-top: 1em;
-  margin-left: 3em;
-  justify-content: center;
+  margin: 1em auto;
+  display: block;
 }
 
 .about-item1 {
@@ -70,8 +67,11 @@
   gap: 20px;
   padding: 10px;
   grid-template-columns: repeat(auto-fit, minmax(225px, 1fr));
-  grid-template-rows: repeat(1, 200px);
+  grid-template-rows: auto;
   padding-bottom: 2em;
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .about-title {


### PR DESCRIPTION
## Summary
Three CSS-only fixes to the broken about-grid layout, specced by the ui-designer agent:

- **`grid-template-rows: auto`** — was `repeat(1, 200px)`, hard-clipping the bio text on most viewports
- **`max-width: 1100px; margin: auto`** on `.about-grid` — bio text was stretching full viewport width on large monitors
- **Portrait margins simplified** — `margin: 20px auto` was being overridden by `margin-top: 1em` and `margin-left: 3em`, breaking centering; replaced with `margin: 1em auto; display: block`

## Test plan
- [ ] Bio text fully visible and not clipped on desktop and mobile
- [ ] Content is centred and capped at 1100px on wide monitors
- [ ] Portrait images are centred within their column

🤖 Generated with [Claude Code](https://claude.com/claude-code)