### PR TITLE
Design polish: navbar, links, select, portrait, typography, spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,14 +30,13 @@
   padding: 14px 16px;
   text-decoration: none;
   border: none;
-  /* Remove default border for select */
   background-color: transparent;
-  /* Make the background transparent for select */
+  transition: color 0.2s ease;
 }
 
-
 .custom-navbar a:hover {
-  background-color: #ddd;
+  background-color: transparent;
+  color: #555555;
 }
 
 .custom-navbar #home {
@@ -46,14 +45,14 @@
 }
 
 .hr-nav {
-  height: 8px;
+  height: 4px;
   border: 0;
-  box-shadow: inset 0 12px 12px -12px rgba(0, 0, 0, 0.5);
+  box-shadow: inset 0 6px 8px -6px rgba(0, 0, 0, 0.2);
 }
 
 .portrait {
-  border-radius: 10px;
-  border: 2px solid rgb(0, 0, 0);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
   max-width: 70%;
   height: auto;
   margin: 1em auto;
@@ -73,10 +72,9 @@
   display: grid;
   /*grid-template-areas: 'portrait text';*/
   gap: 20px;
-  padding: 10px;
   grid-template-columns: repeat(auto-fit, minmax(225px, 1fr));
   grid-template-rows: auto;
-  padding-bottom: 2em;
+  padding: 2em 1.5em 3em;
   max-width: 1100px;
   margin-left: auto;
   margin-right: auto;
@@ -85,6 +83,20 @@
 .about-title {
   font-weight: bold;
   font-size: 2.0em;
+  display: block;
+  margin-bottom: 0.25em;
+}
+
+h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.0rem;
+  font-weight: 400;
+  letter-spacing: 0.03em;
+  margin-bottom: 0.75em;
+}
+
+body {
+  padding-top: 1.5rem;
 }
 
 .text p {
@@ -127,15 +139,17 @@
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  padding: 10px;
-  font-size: 16px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 0.875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 10px 14px;
+  border: 1px solid #bbb;
+  border-radius: 2px;
   background-color: #fff;
   cursor: pointer;
   outline: none;
   width: 100%;
-  text-align: center;
 }
 
 .recording-category select:hover {
@@ -143,8 +157,8 @@
 }
 
 .recording-category select:focus {
-  border-color: #4CAF50;
-  box-shadow: 0 0 5px rgba(76, 175, 80, 0.5);
+  border-color: #999;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
 }
 
 .recording-category option {
@@ -166,6 +180,20 @@ iframe {
 }
 
 
+
+.text a,
+.text a:visited {
+  color: #1a1a1a;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: rgba(0, 0, 0, 0.35);
+  transition: text-decoration-color 0.2s ease;
+}
+
+.text a:hover {
+  color: #000000;
+  text-decoration-color: rgba(0, 0, 0, 0.85);
+}
 
 @media screen and (max-width: 600px) {
 

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -26,8 +26,8 @@
         <h2>Contact</h2>
         <p>
             Please contact to schedule performances and set up lessons. Or about inquiries regarding my research on Ukrainian bassoon music.
-            <br>
-            <br>
+        </p>
+        <p>
             <a href="mailto:zachary.senick@mail.utoronto.ca">Email Me</a>
         </p>
         </div>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -25,14 +25,14 @@
         <div class="text">
         <h2>Lessons</h2>
         <p>
-            I teach all ages ranging from complete beginner to advanced working with students to develop and achieve their unique goals. I have experience preparing for RCM exams, music festival and recital performances, and auditions for honor bands and orchestras. I have experience teaching private lessons, sectionals, and workshops at various summer camps and programs. I have worked at International Music Camp, Vernon Cadet Training Centre Music Program, and with various high school and elementary bands. 
-            <br><br>
-            <b>Location:</b> Online or in-person in Toronto 
-            <br>
-            <b>Instruments:</b> Bassoon, saxophone, flute, and piano 
-            <br>
-            <b>Rates:</b> Inquire about the length and cost of lessons that will work best for your situation 
-            <br><br>
+            I teach all ages ranging from complete beginner to advanced working with students to develop and achieve their unique goals. I have experience preparing for RCM exams, music festival and recital performances, and auditions for honor bands and orchestras. I have experience teaching private lessons, sectionals, and workshops at various summer camps and programs. I have worked at International Music Camp, Vernon Cadet Training Centre Music Program, and with various high school and elementary bands.
+        </p>
+        <p>
+            <b>Location:</b> Online or in-person in Toronto<br>
+            <b>Instruments:</b> Bassoon, saxophone, flute, and piano<br>
+            <b>Rates:</b> Inquire about the length and cost of lessons that will work best for your situation
+        </p>
+        <p>
             Inquire to find out more and <a href="contact.html">contact</a> me about any questions!
         </p>
         </div>


### PR DESCRIPTION
## Summary
10 design improvements specced by the ui-designer agent, implemented by the web-developer agent.

**Navbar**
- Hover state: grey block fill → colour fade (`color: #555`, `transition: 0.2s ease`, transparent background)
- `.hr-nav`: shadow reduced from 8px/0.5 opacity to 4px/0.2 — less heavy

**Portrait**
- Border softened: `2px solid black` → `1px solid rgba(0,0,0,0.18)`
- Border-radius tightened: `10px` → `6px`

**Typography**
- `h2`: now explicitly Playfair Display 2rem weight 400 with `letter-spacing: 0.03em` — was falling back to Bootstrap defaults on Lessons/Contact
- `.about-title`: `display: block; margin-bottom: 0.25em` for proper spacing from body text
- `lessons.html`, `contact.html`: `<br><br>` replaced with `<p>` tags

**Recordings select**
- Font: Montserrat 0.875rem uppercase with `letter-spacing: 0.06em` to match navbar register
- Border: `#ccc` → `#bbb`, `border-radius: 4px` → `2px`
- Focus: `#4CAF50` green removed → `border-color: #999` with neutral box-shadow

**Links**
- `.text a`: Bootstrap blue → `#1a1a1a` with `text-underline-offset: 3px` and fade transition on decoration colour

**Spacing**
- `body`: `padding-top: 1.5rem` — content was flush against the navbar
- `.about-grid`: padding consolidated to `2em 1.5em 3em`

## Test plan
- [ ] Hover over navbar links — should colour-fade, no grey block
- [ ] Check bio/lessons/contact links are dark, not blue
- [ ] Check recordings select focus — no green border
- [ ] Check Lessons and Contact h2 renders in Playfair Display
- [ ] Verify spacing between navbar and page content on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)