### PR TITLE
fix portrait grid layout, alignment, and crop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -72,20 +72,23 @@ body {
 /* ─── Portrait ───────────────────────────────────────────── */
 
 .portrait {
+  grid-area: portrait;
+  align-self: start;
   border-radius: 0;
   border: 3px solid #8b6635;
-  max-width: 70%;
-  height: auto;
-  margin: 1em auto;
+  width: 100%;
+  height: 320px;
+  object-fit: cover;
+  object-position: center 40%;
   display: block;
-  margin: 1em 0;
+  margin: 0 0 1em;
 }
 
 /* ─── Grid layout ────────────────────────────────────────── */
 
 .about-item1 {
   grid-area: portrait;
-  margin: auto;
+  align-self: start;
 }
 
 .about-item2 {
@@ -96,6 +99,7 @@ body {
   display: grid;
   gap: 2.5rem;
   grid-template-columns: 1fr 2fr;
+  grid-template-areas: "portrait text";
   grid-template-rows: auto;
   padding: 2em 1.5em 3em;
   max-width: 1100px;
@@ -126,10 +130,14 @@ h2 {
   margin-bottom: 0.5em;
 }
 
-body {
-  background-color: #faf8f5;
-  color: #2a2420;
-  padding-top: 1.5rem;
+h2::after {
+  content: '';
+  display: block;
+  width: 48px;
+  height: 2px;
+  background: #8b6635;
+  margin-top: 0.5em;
+  margin-bottom: 0.75em;
 }
 
 .text p {
@@ -137,6 +145,7 @@ body {
 }
 
 .text {
+  grid-area: text;
   font-size: 1.05rem;
   font-weight: 400;
   line-height: 1.8;
@@ -253,18 +262,15 @@ iframe {
   margin-top: 0.5em;
 }
 
-.text a,
-.text a:visited {
-  color: #8b6635;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-  text-decoration-color: rgba(139, 102, 53, 0.4);
-  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+.contact-link:hover,
+.contact-link:visited:hover {
+  background: #8b6635;
+  color: #faf8f5;
+  text-decoration: none;
 }
 
-.text a:hover {
-  color: #6e4f28;
-  text-decoration-color: rgba(110, 79, 40, 0.8);
+.contact-link:visited {
+  color: #8b6635;
 }
 
 /* ─── Responsive ─────────────────────────────────────────── */
@@ -272,6 +278,7 @@ iframe {
 @media screen and (max-width: 700px) {
   .about-grid {
     grid-template-columns: 1fr;
+    grid-template-areas: "portrait" "text";
     grid-template-rows: auto;
     padding: 1.5em 1em 2em;
   }


### PR DESCRIPTION
## Summary
- Grid named areas (`portrait`/`text`) so column assignment is correct regardless of DOM order — lessons.html had text as first child, landing it in the narrow 1fr column
- `align-self: start` on portrait elements so photos pin to the top of the grid cell instead of vertically centering when the text column is taller
- `margin: 0 0 1em` removes the top gap that was pushing photos down even with `align-self: start`
- `object-position: center 40%` raises the face higher in the 320px frame
- Removes `body { padding-top: 1.5rem }` that crept back in and caused blank space above the navbar

## Test plan
- [ ] Homepage: two portraits align to top of left column, face visible near top of each frame
- [ ] Lessons: text in wide right column, portrait in narrow left column, face not cut off
- [ ] Contact: portrait in left column, face visible
- [ ] Mobile (< 700px): portrait stacks above text

🤖 Generated with [Claude Code](https://claude.com/claude-code)