### PR TITLE
replace homepage nav-instruction paragraph with CTA buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,6 +248,13 @@ iframe {
 
 /* ─── Contact CTA ────────────────────────────────────────── */
 
+.cta-group {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.5em;
+}
+
 .contact-link {
   display: inline-block;
   font-family: 'Montserrat', sans-serif;

--- a/index.html
+++ b/index.html
@@ -93,10 +93,10 @@
         and maintains an active woodwind private studio. In his free time, Senick is an avid cook, and his favorite
         things to make are вареники (varenyky/perogies) and борщ (borsch).
       </p>
-      <p>
-        The website features recordings and information regarding private lessons. Browse the Recordings tab to find
-        recordings by Ukrainian composers. Browse the Lessons tab for more information on private lessons.
-      </p>
+      <div class="cta-group">
+        <a href="pages/recordings.html" class="contact-link">Recordings</a>
+        <a href="pages/lessons.html" class="contact-link">Lessons</a>
+      </div>
     </div>
 
   </div>


### PR DESCRIPTION
## Summary
- Removes the final bio paragraph that just told users to "Browse the Recordings tab..." — redundant with the navbar
- Replaces it with two outlined gold buttons (Recordings, Lessons) using the existing `.contact-link` style
- Adds `.cta-group` flex container to space them horizontally (wraps on mobile)

## Test plan
- [ ] Homepage: two buttons appear below bio, side by side on desktop
- [ ] Mobile: buttons wrap to separate lines cleanly
- [ ] Both links navigate to the correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)