### PR TITLE
lessons info block, active nav state, single homepage portrait

### DIFF
--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -17,19 +17,18 @@ You are the UI designer for Zachary Senick's personal musician website (zacks22.
 - **Text:** `#2a2420` (dark walnut)
 - **Accent:** `#8b6635` (amber-gold) — used for borders, hover states, hr rules, underlines, CTA buttons
 - **Accent dark:** `#6e4f28` — hover variant
-- **Navbar:** sticky, light background matching body, gold 3px `hr-nav` rule beneath it
-- **Portrait images:** `height: 320px`, `object-fit: cover`, `object-position: center 40%`, gold 3px border, no border-radius
+- **Navbar:** sticky, light background matching body, gold 3px `hr-nav` rule beneath it. Active page link uses `color: #8b6635`.
+- **Portrait images:** `height: 320px`, `object-fit: cover`, `object-position: center 40%`, gold 3px border, no border-radius. Homepage uses a single portrait only.
 - **Grid layout:** `1fr 2fr` two-column with `grid-template-areas: "portrait text"` — portrait narrow left, text wide right. Named areas ensure correct placement regardless of DOM order.
 - **h2:** Playfair Display 400, 2rem, with a 48px × 2px gold rule below via `::after`
 - **h1.about-title:** Playfair Display 700 italic, 2.4rem
 - **CTA buttons:** `.contact-link` class — Montserrat uppercase, gold outline, fills gold on hover. Multiple buttons use `.cta-group` flex container.
+- **Lessons info block:** `.lessons-info` — `background: #f2ede6`, `border-left: 3px solid #8b6635`, `padding: 1em 1.25em`. Labels use `.lessons-label`: Montserrat 0.75rem uppercase, gold, `width: 7em` for alignment.
 - **Mobile breakpoint:** 700px — grid collapses to single column, portrait stacks above text
 
 ## Known design issues (not yet resolved)
-- **Homepage: two stacked portrait photos** in the narrow 1fr column creates awkward height mismatch with the text column. Consider one hero photo or side-by-side within the column.
-- **Navbar: no active state** — the active class detection in JS doesn't reliably fire.
-- **Lessons info block** (`Location`, `Instruments`, `Rates`) uses raw `<b>` tags and looks utilitarian — should be a styled inset block.
 - **No footer** — pages end abruptly. A minimal footer with email and copyright would close the layout properly.
+- **Contact page sparse** — one sentence and an email button. Could use the second portrait photo (removed from homepage) and expanded contact context.
 - **Bio second paragraph** — enormous run-on list of composer commissions. Hard to scan. Longer term: dedicated page or collapsible.
 
 ## Design principles you enforce

--- a/css/style.css
+++ b/css/style.css
@@ -45,6 +45,10 @@ body {
   color: #8b6635;
 }
 
+.custom-navbar .nav-link.active {
+  color: #8b6635 !important;
+}
+
 .custom-navbar #home {
   font-weight: bold;
   font-family: 'Montserrat' !important;
@@ -163,6 +167,27 @@ h2::after {
 .text a:hover {
   color: #6e4f28;
   text-decoration-color: rgba(110, 79, 40, 0.8);
+}
+
+/* ─── Lessons info block ─────────────────────────────────── */
+
+.lessons-info {
+  background: #f2ede6;
+  border-left: 3px solid #8b6635;
+  padding: 1em 1.25em;
+  margin: 1.25em 0;
+  font-size: 1rem;
+  line-height: 2;
+}
+
+.lessons-label {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8b6635;
+  display: inline-block;
+  width: 7em;
 }
 
 /* ─── Recordings ─────────────────────────────────────────── */

--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
   <div class="about-grid">
     <div class="about-item1">
       <img class="portrait" src="img/Headshot_1.JPG" alt="Zachary Senick">
-      <img class="portrait" src="img/Headshot_2024_09.jpg" alt="Zachary Senick">
     </div>
     <div class="text">
       <h1 class="about-title">Zachary Senick (Захар Сенюк)</h1>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -29,11 +29,11 @@
         <p>
             I teach all ages ranging from complete beginner to advanced working with students to develop and achieve their unique goals. I have experience preparing for RCM exams, music festival and recital performances, and auditions for honor bands and orchestras. I have experience teaching private lessons, sectionals, and workshops at various summer camps and programs. I have worked at International Music Camp, Vernon Cadet Training Centre Music Program, and with various high school and elementary bands.
         </p>
-        <p>
-            <b>Location:</b> Online or in-person in Toronto<br>
-            <b>Instruments:</b> Bassoon, saxophone, flute, and piano<br>
-            <b>Rates:</b> Inquire about the length and cost of lessons that will work best for your situation
-        </p>
+        <div class="lessons-info">
+            <div><span class="lessons-label">Location</span> Online or in-person in Toronto</div>
+            <div><span class="lessons-label">Instruments</span> Bassoon, saxophone, flute, and piano</div>
+            <div><span class="lessons-label">Rates</span> Inquire about length and cost</div>
+        </div>
         <p>
             Inquire to find out more and <a href="contact.html">contact</a> me about any questions!
         </p>

--- a/scripts/navbar.js
+++ b/scripts/navbar.js
@@ -22,9 +22,10 @@ function generateNavbar() {
     `;
 
     navLinks.slice(1).forEach(function(link) {
+        var linkPath = link.href.split('?')[0];
         navbarHtml += `
             <li class="nav-item">
-                <a class="nav-link ${currentPage === link.href ? 'active' : ''}" href="${fixedLocation}${link.href}">${link.text}</a>
+                <a class="nav-link ${currentPage === linkPath ? 'active' : ''}" href="${fixedLocation}${link.href}">${link.text}</a>
             </li>
         `;
     });


### PR DESCRIPTION
## Summary
- **Lessons info block** — replaces raw `<b>Location:</b>...<br>` with a `.lessons-info` styled inset card: warm tinted background (`#f2ede6`), gold left border, Montserrat uppercase labels with fixed width for alignment
- **Navbar active state** — strips query string from link href before comparing to `window.location.pathname`; Recordings link was never matching because it included `?category=world-premieres`
- **Homepage single portrait** — removes second stacked portrait image; one hero photo looks cleaner and avoids the column height mismatch

## Test plan
- [ ] Lessons: info block renders as tinted inset with gold left border
- [ ] Navigate to each page: current page link highlights gold in navbar
- [ ] Homepage: single portrait, left column height matches the bio more naturally
- [ ] Mobile: lessons info block readable, labels wrap gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)