### PR TITLE
add footer to all pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -305,6 +305,47 @@ iframe {
   color: #8b6635;
 }
 
+/* ─── Footer ─────────────────────────────────────────────── */
+
+footer {
+  border-top: 1px solid rgba(139, 102, 53, 0.25);
+  margin-top: 4em;
+  padding: 2.5em 1.5em;
+  text-align: center;
+  font-family: 'Montserrat', sans-serif;
+  letter-spacing: 0.08em;
+}
+
+.footer-name {
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  color: #2a2420;
+  margin-bottom: 0.5em;
+}
+
+.footer-meta {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #8b6635;
+  margin: 0;
+}
+
+.footer-meta a {
+  color: #8b6635;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer-meta a:hover {
+  color: #6e4f28;
+}
+
+.footer-sep {
+  margin: 0 0.75em;
+  opacity: 0.4;
+}
+
 /* ─── Responsive ─────────────────────────────────────────── */
 
 @media screen and (max-width: 700px) {

--- a/index.html
+++ b/index.html
@@ -100,6 +100,15 @@
 
   </div>
 
+  <footer>
+    <p class="footer-name">Zachary Senick</p>
+    <p class="footer-meta">
+      <a href="mailto:zachary.senick@mail.utoronto.ca">zachary.senick@mail.utoronto.ca</a>
+      <span class="footer-sep">·</span>
+      © 2025 Zachary Senick
+    </p>
+  </footer>
+
   <!-- Local Script -->
   <script type="text/javascript" src="index.js"></script>
 

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -33,6 +33,15 @@
         </div>
     </div>
 
+    <footer>
+      <p class="footer-name">Zachary Senick</p>
+      <p class="footer-meta">
+        <a href="mailto:zachary.senick@mail.utoronto.ca">zachary.senick@mail.utoronto.ca</a>
+        <span class="footer-sep">·</span>
+        © 2025 Zachary Senick
+      </p>
+    </footer>
+
     <!-- Local Script -->
     <script type="text/javascript" src="contact.js"></script>
 

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -42,6 +42,15 @@
     </div>
     </section>
 
+    <footer>
+      <p class="footer-name">Zachary Senick</p>
+      <p class="footer-meta">
+        <a href="mailto:zachary.senick@mail.utoronto.ca">zachary.senick@mail.utoronto.ca</a>
+        <span class="footer-sep">·</span>
+        © 2025 Zachary Senick
+      </p>
+    </footer>
+
     <!-- Local Script -->
     <script type="text/javascript" src="lessons.js"></script>
 

--- a/pages/recordings.html
+++ b/pages/recordings.html
@@ -42,6 +42,15 @@
     <!-- Create the main Recording content -->
     <div id="recordings-container"></div>
 
+    <footer>
+      <p class="footer-name">Zachary Senick</p>
+      <p class="footer-meta">
+        <a href="mailto:zachary.senick@mail.utoronto.ca">zachary.senick@mail.utoronto.ca</a>
+        <span class="footer-sep">·</span>
+        © 2025 Zachary Senick
+      </p>
+    </footer>
+
     <!-- Local Script -->
     <script type="text/javascript" src="recordings.js"></script>
 


### PR DESCRIPTION
## Summary
- Adds a `<footer>` to all four pages (home, recordings, lessons, contact)
- Name in Montserrat 500 uppercase (`#2a2420`), email + copyright in gold Montserrat below, separated by a mid-dot
- Faint gold top border (`rgba(139, 102, 53, 0.25)`) mirrors the `hr-nav` from the top — closes the page visually
- No scripts, no injection — plain HTML on each page

## Test plan
- [ ] Footer appears on all four pages
- [ ] Email link opens mail client
- [ ] Top border aligns with the site's gold accent
- [ ] Looks correct on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)