### PR TITLE
add composer filter to recordings page

### DIFF
--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -23,11 +23,14 @@ You are the UI designer for Zachary Senick's personal musician website (zacks22.
 - **h2:** Playfair Display 400, 2rem, with a 48px × 2px gold rule below via `::after`
 - **h1.about-title:** Playfair Display 700 italic, 2.4rem
 - **CTA buttons:** `.contact-link` class — Montserrat uppercase, gold outline, fills gold on hover. Multiple buttons use `.cta-group` flex container.
-- **Lessons info block:** `.lessons-info` — `background: #f2ede6`, `border-left: 3px solid #8b6635`, `padding: 1em 1.25em`. Labels use `.lessons-label`: Montserrat 0.75rem uppercase, gold, `width: 7em` for alignment.
-- **Mobile breakpoint:** 700px — grid collapses to single column, portrait stacks above text
+- **Lessons info block:** `.lessons-info` — `background: #f2ede6`, `border-left: 3px solid #8b6635`, `padding: 1em 1.25em`. Rows use `display: flex; gap: 1em`. Labels use `.lessons-label`: Montserrat 0.75rem uppercase, gold, `flex: 0 0 6.5rem` — flex fixed-width required to prevent value text bleeding under label.
+- **Recording cards:** `.recording-card` — `background: #fdf9f4` (warm near-white, not pure white), `border: 1px solid rgba(139,102,53,0.2)`, flex column. Video iframe sits flush above card body. Meta line (composer + year) in Montserrat 0.8rem uppercase with gold bottom border. Title in Playfair italic. Ukrainian title and movement/performer details in Montserrat at 0.65rem and 0.6rem respectively.
+- **Recording filters:** Two side-by-side dropdowns (category + composer) in a flex row, `max-width: 720px` centered. All selects use `appearance: none` with an inline SVG chevron via `background-image` (`right 12px center`) to restore the dropdown indicator. Right padding `36px` to avoid text overlapping chevron.
+- **Recordings grid:** `repeat(2, 1fr)` two-column card grid, `max-width: 1200px`, collapses to 1-column at 700px.
+- **Footer:** minimal — name in Montserrat 500 uppercase, email + copyright in Montserrat 0.75rem uppercase gold. `border-top: 1px solid rgba(139,102,53,0.25)`. Present on all pages.
+- **Mobile breakpoint:** 700px — grid collapses to single column, portrait stacks above text, recordings grid goes 1-column
 
 ## Known design issues (not yet resolved)
-- **No footer** — pages end abruptly. A minimal footer with email and copyright would close the layout properly.
 - **Contact page sparse** — one sentence and an email button. Could use the second portrait photo (removed from homepage) and expanded contact context.
 - **Bio second paragraph** — enormous run-on list of composer commissions. Hard to scan. Longer term: dedicated page or collapsible.
 

--- a/.claude/agents/web-developer.md
+++ b/.claude/agents/web-developer.md
@@ -23,7 +23,12 @@ You are the web developer for Zachary Senick's personal musician website (zacks2
 
 ## Recordings page
 - All categories rendered at page load in `data-category` wrapper divs. Filter works by toggling `display` — no `window.location` navigation. This was a deliberate performance fix.
-- `scripts/generateRecordings.js` handles rendering and `showCategory()` toggling.
+- `scripts/generateRecordings.js` handles rendering, category toggling, and composer filtering.
+- **Card layout:** each recording renders as `.recording-card` inside `.recordings-grid` (2-column CSS grid). Cards use `display: flex; flex-direction: column` so card body stretches to fill height. Iframe is flush above card body (no padding wrapper around iframe).
+- **Composer filter:** `data-composer` attribute on each card (slugified lowercase composer name). `window._recordingsGrouped` stores the parsed JSON grouped by category slug — used by `populateComposerFilter()` to rebuild the composer dropdown on each category switch. `showComposer()` toggles card `display` by matching `card.dataset.composer`. Composer select resets to "all" on every category change.
+- **Recordings page heading:** wrapped in `.recordings-header` div (plain `max-width: 1200px` container), NOT `.about-grid` — using `about-grid` as the heading wrapper broke card layout by injecting `grid-template-areas` constraints.
+- The select dropdowns use `appearance: none` to remove native browser chrome, with an inline SVG chevron as `background-image`. `pages/recordings.js` attaches jQuery `.change()` listeners for both `#selectCategory` and `#selectComposer`.
+- **Lessons info block:** `.lessons-info > div` uses `display: flex; gap: 1em`. `.lessons-label` uses `flex: 0 0 6.5rem` — this is required. `inline-block` with `width` was tried and failed because wrapped value text bled under the label.
 
 ## jQuery / Bootstrap
 - Use jQuery 3.6.4 only. The old `jquery-1.12.4` was removed — do not reintroduce it.

--- a/css/style.css
+++ b/css/style.css
@@ -227,9 +227,12 @@ h2::after {
   font-size: 0.875rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 10px 14px;
+  padding: 10px 36px 10px 14px;
   border: 1px solid #8b6635;
   border-radius: 2px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238b6635' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
   background-color: #faf8f5;
   color: #2a2420;
   cursor: pointer;

--- a/css/style.css
+++ b/css/style.css
@@ -198,6 +198,21 @@ h2::after {
 
 /* ─── Recordings ─────────────────────────────────────────── */
 
+.recording-filters {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  max-width: 720px;
+  margin: 2em auto;
+  padding: 0 1.5rem;
+}
+
+.recording-filters .recording-category {
+  flex: 1;
+  width: auto;
+  margin: 0;
+}
+
 .recording-category {
   text-align: center;
   width: min(60%, 340px);

--- a/pages/recordings.html
+++ b/pages/recordings.html
@@ -26,15 +26,22 @@
       <h2>Recordings</h2>
     </div>
 
-    <!-- Select field for recording category -->
-    <div class="recording-category">
-      <select name="selectCategory" id="selectCategory">
-        <option value="world-premieres">World Premieres &#9660;</option>
-        <option value="ukrainian-solo-rep">Ukrainian Solo Rep &#9660;</option>
-        <option value="ukrainian-chamber-rep">Ukrainian Chamber Rep &#9660;</option>
-        <option value="other-slavic-rep">Other Slavic Rep &#9660;</option>
-        <option value="standard-rep">Standard Rep &#9660;</option>
-      </select>
+    <!-- Recording filters -->
+    <div class="recording-filters">
+      <div class="recording-category">
+        <select name="selectCategory" id="selectCategory">
+          <option value="world-premieres">World Premieres</option>
+          <option value="ukrainian-solo-rep">Ukrainian Solo Rep</option>
+          <option value="ukrainian-chamber-rep">Ukrainian Chamber Rep</option>
+          <option value="other-slavic-rep">Other Slavic Rep</option>
+          <option value="standard-rep">Standard Rep</option>
+        </select>
+      </div>
+      <div class="recording-category">
+        <select name="selectComposer" id="selectComposer">
+          <option value="all">All Composers</option>
+        </select>
+      </div>
     </div>
 
     <!-- Create the main Recording content -->

--- a/pages/recordings.js
+++ b/pages/recordings.js
@@ -6,3 +6,7 @@ document.addEventListener('DOMContentLoaded', function() {
 $("#selectCategory").change(function() {
     showCategory(this.value);
 });
+
+$("#selectComposer").change(function() {
+    showComposer(this.value);
+});

--- a/scripts/generateRecordings.js
+++ b/scripts/generateRecordings.js
@@ -2,6 +2,10 @@ function categoryToSlug(category) {
     return category.trim().toLowerCase().replace(/\s+/g, '-');
 }
 
+function composerToSlug(composer) {
+    return composer.trim().toLowerCase();
+}
+
 async function generateRecordings() {
     const response = await fetch('../data/recordings.json');
     const allRecordings = await response.json();
@@ -14,6 +18,9 @@ async function generateRecordings() {
         if (!grouped[slug]) grouped[slug] = [];
         grouped[slug].push(recording);
     });
+
+    // Store for use by composer filter
+    window._recordingsGrouped = grouped;
 
     let html = '';
     Object.keys(grouped).forEach(function(slug) {
@@ -28,7 +35,7 @@ async function generateRecordings() {
             const performers = recording.performers.map(p => `<div>${p}</div>`).join('');
 
             html += `
-            <div class="recording-card">
+            <div class="recording-card" data-composer="${composerToSlug(recording.composer)}">
                 <div class="recording-card-meta">${recording.composer}${year}</div>
                 <iframe src="${recording.embedVideoUrl}" title="${recording.composer}: ${recording.title}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"></iframe>
                 <div class="recording-card-body">
@@ -47,8 +54,40 @@ async function generateRecordings() {
     showCategory(document.getElementById('selectCategory').value);
 }
 
+function populateComposerFilter(categorySlug) {
+    const recordings = (window._recordingsGrouped || {})[categorySlug] || [];
+    const seen = new Set();
+    const composers = [];
+    recordings.forEach(function(r) {
+        if (!seen.has(r.composer)) {
+            seen.add(r.composer);
+            composers.push(r.composer);
+        }
+    });
+
+    const select = document.getElementById('selectComposer');
+    select.innerHTML = '<option value="all">All Composers</option>';
+    composers.forEach(function(composer) {
+        const option = document.createElement('option');
+        option.value = composerToSlug(composer);
+        option.textContent = composer;
+        select.appendChild(option);
+    });
+}
+
 function showCategory(slug) {
     document.querySelectorAll('.category-section').forEach(function(el) {
         el.style.display = el.dataset.category === slug ? '' : 'none';
+    });
+    populateComposerFilter(slug);
+    document.getElementById('selectComposer').value = 'all';
+}
+
+function showComposer(composerSlug) {
+    const categorySlug = document.getElementById('selectCategory').value;
+    const activeSection = document.querySelector(`.category-section[data-category="${categorySlug}"]`);
+    if (!activeSection) return;
+    activeSection.querySelectorAll('.recording-card').forEach(function(card) {
+        card.style.display = (composerSlug === 'all' || card.dataset.composer === composerSlug) ? '' : 'none';
     });
 }


### PR DESCRIPTION
## Summary
Adds a second dropdown filter for composer, sitting alongside the existing category filter.

**Behaviour:**
- Composer dropdown is populated dynamically from the composers in the currently selected category
- Switching category resets composer to "All Composers" and repopulates the list
- Selecting a composer hides non-matching cards within that category (cards stay in the DOM, just `display: none`)
- "All Composers" restores all cards

**Changes:**
- `recordings.html` — wraps both selects in `.recording-filters` flex row, removes `&#9660;` arrow glyphs from options (redundant with the custom `appearance: none` select style)
- `generateRecordings.js` — adds `data-composer` attribute to each card, `populateComposerFilter()`, `showComposer()`
- `recordings.js` — wires up `#selectComposer` change listener
- `style.css` — `.recording-filters` flex layout, overrides `.recording-category` width/margin within the row

## Test plan
- [ ] Both dropdowns appear side by side
- [ ] Switching category updates composer list and resets to All
- [ ] Selecting a composer filters cards correctly
- [ ] "All Composers" shows all cards in current category
- [ ] Works on mobile (dropdowns stack or remain usable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)