### PR TITLE
Redesign contact page

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -23,13 +23,22 @@
 
     <!-- Create the main Contact content -->
     <div class="about-grid">
-        <img class="portrait" src="../img/Senick_Headshot_prev.jpg" alt="Zachary Senick">
+        <img class="portrait" src="../img/Headshot_2024_09.jpg" alt="Zachary Senick">
         <div class="text">
-        <h2>Contact</h2>
-        <p>
-            Please contact to schedule performances and set up lessons. Or about inquiries regarding my research on Ukrainian bassoon music.
-        </p>
-        <a href="mailto:zachary.senick@mail.utoronto.ca" class="contact-link">Email Me</a>
+          <h2>Contact</h2>
+          <p>
+            Available for solo and chamber performances, new music premieres, and collaborative projects. Please reach out to discuss programming, scheduling, and fees.
+          </p>
+          <p>
+            Offering bassoon, saxophone, flute, and piano lessons for students of all levels, online or in-person in Toronto. Contact to inquire about availability and rates.
+          </p>
+          <p>
+            For questions about Ukrainian bassoon repertoire, ongoing research, or academic collaboration, I am happy to correspond.
+          </p>
+          <div class="cta-group">
+            <a href="mailto:zachary.senick@mail.utoronto.ca" class="contact-link">Email Me</a>
+            <a href="lessons.html" class="contact-link">Lessons</a>
+          </div>
         </div>
     </div>
 

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -27,10 +27,10 @@
         <div class="text">
           <h2>Contact</h2>
           <p>
-            Available for solo and chamber performances, new music premieres, and collaborative projects. Please reach out to discuss programming, scheduling, and fees.
+            Available for solo and chamber performances, new music premieres, and collaborative projects. Please reach out to discuss.
           </p>
           <p>
-            Offering bassoon, saxophone, flute, and piano lessons for students of all levels, online or in-person in Toronto. Contact to inquire about availability and rates.
+            Offering bassoon, saxophone, flute, and piano lessons for students of all levels, online or in-person in Toronto. Contact to inquire about availability.
           </p>
           <p>
             For questions about Ukrainian bassoon repertoire, ongoing research, or academic collaboration, I am happy to correspond.


### PR DESCRIPTION
## Summary
- Switches portrait to `Headshot_2024_09.jpg` (the second photo removed from homepage, previously unused)
- Replaces one vague sentence with three focused paragraphs: performances, lessons, research
- Adds `cta-group` with **Email Me** and **Lessons** buttons side by side

## Test plan
- [ ] Portrait loads and is cropped correctly in the grid layout
- [ ] All three paragraphs render at appropriate width in the right column
- [ ] Both CTA buttons appear side by side and link correctly (email opens mail client, Lessons navigates to lessons.html)
- [ ] Layout collapses correctly at mobile breakpoint (700px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)